### PR TITLE
Fix for Issue #2

### DIFF
--- a/db/migrate/20150822182332_alter_orders_change_column_postal_to_varchar.rb
+++ b/db/migrate/20150822182332_alter_orders_change_column_postal_to_varchar.rb
@@ -1,0 +1,5 @@
+class AlterOrdersChangeColumnPostalToVarchar < ActiveRecord::Migration
+  def change
+    change_column :orders, :postal, :string, :limit => 10
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150526222746) do
+ActiveRecord::Schema.define(version: 20150822182332) do
 
   create_table "comments", force: :cascade do |t|
     t.integer  "order_id",   limit: 4
@@ -20,15 +20,13 @@ ActiveRecord::Schema.define(version: 20150526222746) do
     t.datetime "updated_at",             null: false
   end
 
-  add_index "comments", ["order_id"], name: "fk_rails_453b7b85cf", using: :btree
-
   create_table "orders", force: :cascade do |t|
     t.string   "name",       limit: 255
     t.string   "street",     limit: 255
     t.string   "city",       limit: 255
     t.string   "state",      limit: 255
     t.string   "country",    limit: 255
-    t.integer  "postal",     limit: 4
+    t.string   "postal",     limit: 10
     t.integer  "quantity",   limit: 4
     t.boolean  "shipped",    limit: 1,   default: false
     t.datetime "created_at",                             null: false
@@ -37,5 +35,4 @@ ActiveRecord::Schema.define(version: 20150526222746) do
 
   add_index "orders", ["shipped"], name: "index_orders_on_shipped", using: :btree
 
-  add_foreign_key "comments", "orders"
 end

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -66,20 +66,17 @@ class OrderTest < ActiveSupport::TestCase
     @new_order.errors[:postal].must_equal ['Invalid Postal Code']
   end
 
-  # @todo Update table 'orders' such that 'orders.postal' is a varchar
-  # test 'Validates Add-on Postal Code is Long Enough' do
-  #   @new_order.postal = '12345-678'
-  #   puts @new_order.inspect
-  #   @new_order.wont_be :valid?
-  #   @new_order.errors[:postal].must_equal ['Invalid Postal Code']
-  # end
+  test 'Validates Add-on Postal Code is Long Enough' do
+    @new_order.postal = '12345-678'
+    @new_order.wont_be :valid?
+    @new_order.errors[:postal].must_equal ['Invalid Postal Code']
+  end
 
-  # test 'Validates Add-on Postal Code not Too Long' do
-  #   @new_order.postal = '12345-67890'
-  #   puts @new_order.inspect
-  #   @new_order.wont_be :valid?
-  #   @new_order.errors[:postal].must_equal ['Invalid Postal Code']
-  # end
+  test 'Validates Add-on Postal Code not Too Long' do
+    @new_order.postal = '12345-67890'
+    @new_order.wont_be :valid?
+    @new_order.errors[:postal].must_equal ['Invalid Postal Code']
+  end
 
   # Test Callbacks
   test 'Can call send_pusher' do


### PR DESCRIPTION
Fixes issue #2 such that `orders.postal` is now a VARCHAR(10), and the correct ZIP/postal code with an 'add-on' can be entered, and that such formatting has test coverage.
